### PR TITLE
Fix getting champ names

### DIFF
--- a/src/app/summoner/[regionId]/[gameName_tagLine]/page.jsx
+++ b/src/app/summoner/[regionId]/[gameName_tagLine]/page.jsx
@@ -53,7 +53,7 @@ export default async function Page({ params, searchParams }) {
   return (
     <div className="bg-gray-100 p-6">
       <div className="mb-6 flex items-center">
-        <ProfileIcon profileIconId={summonerProfile.profileIconId} />
+        <ProfileIcon profileIconId={summonerProfile.profileIconId} className="size-16 md:size-24 lg:size-32" />
         <div className="ml-4">
           <h1 className="text-3xl font-bold">
             {summonerProfile.gameName}#{summonerProfile.tagLine}
@@ -104,7 +104,12 @@ export default async function Page({ params, searchParams }) {
             Aram
           </Link>
         </div>
-        <MatchHistory matches={matchHistory} regionId={regionId} summonerName={summonerProfile.gameName} />
+        <MatchHistory
+          matches={matchHistory}
+          regionId={regionId}
+          summonerName={summonerProfile.gameName}
+          championNames={championNames}
+        />
       </div>
 
       {process.env.NEXT_PUBLIC_DEBUG_MODE == "true" && (

--- a/src/components/champion-icon.jsx
+++ b/src/components/champion-icon.jsx
@@ -3,14 +3,14 @@ import { DATA_DRAGON_ASSETS_PATH } from "@/constants/data-dragon";
 
 // const SUPABASE_ASSET_PATH = '/storage/v1/object/public/league-assets';
 
-export function ChampionIcon({ championName, size = 32, className }) {
+export function ChampionIcon({ championName, className }) {
   return (
     <Image
       src={`${DATA_DRAGON_ASSETS_PATH}/img/champion/${championName}.png`}
       alt={championName}
       className={`${className}`}
-      width={size}
-      height={size}
+      width={128}
+      height={128}
     />
   );
 }

--- a/src/components/champion-icon.jsx
+++ b/src/components/champion-icon.jsx
@@ -3,15 +3,14 @@ import { DATA_DRAGON_ASSETS_PATH } from "@/constants/data-dragon";
 
 // const SUPABASE_ASSET_PATH = '/storage/v1/object/public/league-assets';
 
-export function ChampionIcon({ championName, size = 32 }) {
+export function ChampionIcon({ championName, size = 32, className }) {
   return (
     <Image
       src={`${DATA_DRAGON_ASSETS_PATH}/img/champion/${championName}.png`}
       alt={championName}
-      className="size-full object-cover"
+      className={`${className}`}
       width={size}
       height={size}
-      unoptimized
     />
   );
 }

--- a/src/components/champion-masteries.jsx
+++ b/src/components/champion-masteries.jsx
@@ -26,8 +26,12 @@ export async function ChampionMasteries({ masteries, championNames }) {
           className="relative flex items-center gap-4 rounded-lg border bg-gradient-to-b from-slate-50 to-slate-100 p-4 pb-8 shadow-md md:flex-col md:items-center"
         >
           <div className="relative">
-            <div className="relative size-16 overflow-hidden rounded-lg ring-2 ring-black/10">
-              <ChampionIcon championName={championNames[mastery.championId]} size={64} />
+            <div className="relative overflow-hidden rounded-lg ring-2 ring-black/10">
+              <ChampionIcon
+                championName={championNames[mastery.championId]}
+                size={128}
+                className="size-10 md:size-12 lg:size-16"
+              />
             </div>
             <MasteryLevel level={mastery.championLevel} />
           </div>

--- a/src/components/champion-masteries.jsx
+++ b/src/components/champion-masteries.jsx
@@ -29,7 +29,6 @@ export async function ChampionMasteries({ masteries, championNames }) {
             <div className="relative overflow-hidden rounded-lg ring-2 ring-black/10">
               <ChampionIcon
                 championName={championNames[mastery.championId]}
-                size={128}
                 className="size-10 md:size-12 lg:size-16"
               />
             </div>

--- a/src/components/item-icon.jsx
+++ b/src/components/item-icon.jsx
@@ -3,17 +3,15 @@ import { DATA_DRAGON_ASSETS_PATH } from "@/constants/data-dragon";
 
 // const SUPABASE_ASSET_PATH = '/storage/v1/object/public/league-assets';
 
-export function ItemIcon({ itemId, size = 24 }) {
+export function ItemIcon({ itemId, size = 24, className }) {
   if (!itemId || itemId === 0) return <div style={{ width: size, height: size }} className="rounded bg-gray-200" />;
-
   return (
     <Image
+      className={`rounded ${className}`}
       src={`${DATA_DRAGON_ASSETS_PATH}/img/item/${itemId}.png`}
       alt={`Item ${itemId}`}
-      className="rounded"
       width={size}
       height={size}
-      unoptimized
     />
   );
 }

--- a/src/components/item-icon.jsx
+++ b/src/components/item-icon.jsx
@@ -3,15 +3,15 @@ import { DATA_DRAGON_ASSETS_PATH } from "@/constants/data-dragon";
 
 // const SUPABASE_ASSET_PATH = '/storage/v1/object/public/league-assets';
 
-export function ItemIcon({ itemId, size = 24, className }) {
-  if (!itemId || itemId === 0) return <div style={{ width: size, height: size }} className="rounded bg-gray-200" />;
+export function ItemIcon({ itemId, className }) {
+  if (!itemId || itemId === 0) return <div className={`rounded bg-gray-200 ${className}`} />;
   return (
     <Image
       className={`rounded ${className}`}
       src={`${DATA_DRAGON_ASSETS_PATH}/img/item/${itemId}.png`}
       alt={`Item ${itemId}`}
-      width={size}
-      height={size}
+      width={64}
+      height={64}
     />
   );
 }

--- a/src/components/mastery-icon.jsx
+++ b/src/components/mastery-icon.jsx
@@ -11,7 +11,7 @@ export function MasteryIcon({ level, size = 24 }) {
     4: 4,
     3: 3,
     2: 2,
-    1: 1
+    1: 1,
   };
 
   const iconNumber = masteryIconMap[level] || 1;
@@ -23,7 +23,6 @@ export function MasteryIcon({ level, size = 24 }) {
       className="absolute -bottom-2 -right-2 z-10"
       width={size}
       height={size}
-      unoptimized
     />
   );
-} 
+}

--- a/src/components/match-history.jsx
+++ b/src/components/match-history.jsx
@@ -4,7 +4,7 @@ import { ChampionIcon } from "./champion-icon";
 import Link from "next/link";
 import { ItemIcon } from "./item-icon";
 
-export function MatchHistory({ matches, regionId, summonerName }) {
+export function MatchHistory({ matches, regionId, summonerName, championNames }) {
   if (!matches || !Array.isArray(matches)) {
     return <div>No matches found</div>;
   }
@@ -39,9 +39,13 @@ export function MatchHistory({ matches, regionId, summonerName }) {
 
                 {/* Champion and Summoner Info in preview */}
                 <div className="flex items-center gap-2">
-                  <ProfileIcon profileIconId={currentPlayer.profileIcon} size={32} />
-                  <div className="size-7 overflow-hidden">
-                    <ChampionIcon championName={currentPlayer.championName} size={28} />
+                  <ProfileIcon profileIconId={currentPlayer.profileIcon} className="size-12 lg:size-14" />
+                  <div className="overflow-hidden">
+                    <ChampionIcon
+                      championName={championNames[currentPlayer.championId]}
+                      size={128}
+                      className="size-6 lg:size-7"
+                    />
                   </div>
                 </div>
 
@@ -94,11 +98,13 @@ export function MatchHistory({ matches, regionId, summonerName }) {
                             prefetch
                             href={`/summoner/${regionId}/${participant.riotIdGameName}-${participant.riotIdTagline}`}
                           >
-                            <ProfileIcon profileIconId={participant.profileIcon} size={32} />
+                            <ProfileIcon profileIconId={participant.profileIcon} className="size-12 lg:size-14" />
                           </Link>
-                          <div className="size-6">
-                            <ChampionIcon championName={participant.championName} size={24} />
-                          </div>
+                          <ChampionIcon
+                            championName={championNames[participant.championId]}
+                            size={24}
+                            className="size-6 lg:size-7"
+                          />
                         </div>
                         <div className="ml-2 grow">
                           <div className="flex items-center">
@@ -140,11 +146,13 @@ export function MatchHistory({ matches, regionId, summonerName }) {
                             prefetch
                             href={`/summoner/${regionId}/${participant.riotIdGameName}-${participant.riotIdTagline}`}
                           >
-                            <ProfileIcon profileIconId={participant.profileIcon} size={32} />
+                            <ProfileIcon profileIconId={participant.profileIcon} className="size-12 lg:size-14" />
                           </Link>
-                          <div className="size-6">
-                            <ChampionIcon championName={participant.championName} size={24} />
-                          </div>
+                          <ChampionIcon
+                            championName={championNames[participant.championId]}
+                            size={24}
+                            className="size-6 lg:size-7"
+                          />
                         </div>
                         <div className="ml-2 grow">
                           <div className="flex items-center">

--- a/src/components/match-history.jsx
+++ b/src/components/match-history.jsx
@@ -41,11 +41,7 @@ export function MatchHistory({ matches, regionId, summonerName, championNames })
                 <div className="flex items-center gap-2">
                   <ProfileIcon profileIconId={currentPlayer.profileIcon} className="size-12 lg:size-14" />
                   <div className="overflow-hidden">
-                    <ChampionIcon
-                      championName={championNames[currentPlayer.championId]}
-                      size={128}
-                      className="size-6 lg:size-7"
-                    />
+                    <ChampionIcon championName={championNames[currentPlayer.championId]} className="size-6 lg:size-7" />
                   </div>
                 </div>
 
@@ -68,13 +64,13 @@ export function MatchHistory({ matches, regionId, summonerName, championNames })
 
                 {/* Items */}
                 <div className="flex gap-1">
-                  <ItemIcon itemId={currentPlayer.item0} size={24} />
-                  <ItemIcon itemId={currentPlayer.item1} size={24} />
-                  <ItemIcon itemId={currentPlayer.item2} size={24} />
-                  <ItemIcon itemId={currentPlayer.item3} size={24} />
-                  <ItemIcon itemId={currentPlayer.item4} size={24} />
-                  <ItemIcon itemId={currentPlayer.item5} size={24} />
-                  <ItemIcon itemId={currentPlayer.item6} size={24} />
+                  <ItemIcon itemId={currentPlayer.item0} className="size-6" />
+                  <ItemIcon itemId={currentPlayer.item1} className="size-6" />
+                  <ItemIcon itemId={currentPlayer.item2} className="size-6" />
+                  <ItemIcon itemId={currentPlayer.item3} className="size-6" />
+                  <ItemIcon itemId={currentPlayer.item4} className="size-6" />
+                  <ItemIcon itemId={currentPlayer.item5} className="size-6" />
+                  <ItemIcon itemId={currentPlayer.item6} className="size-6" />
                 </div>
 
                 {/* Game Time */}
@@ -102,7 +98,6 @@ export function MatchHistory({ matches, regionId, summonerName, championNames })
                           </Link>
                           <ChampionIcon
                             championName={championNames[participant.championId]}
-                            size={24}
                             className="size-6 lg:size-7"
                           />
                         </div>
@@ -121,13 +116,13 @@ export function MatchHistory({ matches, regionId, summonerName, championNames })
                             </span>
                           </div>
                           <div className="mt-1 flex gap-1">
-                            <ItemIcon itemId={participant.item0} size={20} />
-                            <ItemIcon itemId={participant.item1} size={20} />
-                            <ItemIcon itemId={participant.item2} size={20} />
-                            <ItemIcon itemId={participant.item3} size={20} />
-                            <ItemIcon itemId={participant.item4} size={20} />
-                            <ItemIcon itemId={participant.item5} size={20} />
-                            <ItemIcon itemId={participant.item6} size={20} />
+                            <ItemIcon itemId={participant.item0} className="size-5" />
+                            <ItemIcon itemId={participant.item1} className="size-5" />
+                            <ItemIcon itemId={participant.item2} className="size-5" />
+                            <ItemIcon itemId={participant.item3} className="size-5" />
+                            <ItemIcon itemId={participant.item4} className="size-5" />
+                            <ItemIcon itemId={participant.item5} className="size-5" />
+                            <ItemIcon itemId={participant.item6} className="size-5" />
                           </div>
                         </div>
                       </div>
@@ -150,7 +145,6 @@ export function MatchHistory({ matches, regionId, summonerName, championNames })
                           </Link>
                           <ChampionIcon
                             championName={championNames[participant.championId]}
-                            size={24}
                             className="size-6 lg:size-7"
                           />
                         </div>
@@ -169,13 +163,13 @@ export function MatchHistory({ matches, regionId, summonerName, championNames })
                             </span>
                           </div>
                           <div className="mt-1 flex gap-1">
-                            <ItemIcon itemId={participant.item0} size={20} />
-                            <ItemIcon itemId={participant.item1} size={20} />
-                            <ItemIcon itemId={participant.item2} size={20} />
-                            <ItemIcon itemId={participant.item3} size={20} />
-                            <ItemIcon itemId={participant.item4} size={20} />
-                            <ItemIcon itemId={participant.item5} size={20} />
-                            <ItemIcon itemId={participant.item6} size={20} />
+                            <ItemIcon itemId={participant.item0} className="size-5" />
+                            <ItemIcon itemId={participant.item1} className="size-5" />
+                            <ItemIcon itemId={participant.item2} className="size-5" />
+                            <ItemIcon itemId={participant.item3} className="size-5" />
+                            <ItemIcon itemId={participant.item4} className="size-5" />
+                            <ItemIcon itemId={participant.item5} className="size-5" />
+                            <ItemIcon itemId={participant.item6} className="size-5" />
                           </div>
                         </div>
                       </div>

--- a/src/components/profile-icon.jsx
+++ b/src/components/profile-icon.jsx
@@ -2,10 +2,10 @@ import { Avatar, AvatarImage, AvatarFallback } from "./ui/avatar";
 import { Icons } from "./icons";
 import { DATA_DRAGON_ASSETS_PATH } from "@/constants/data-dragon";
 
-const ProfileIcon = ({ profileIconId }) => {
+const ProfileIcon = ({ profileIconId, className }) => {
   const src = `${DATA_DRAGON_ASSETS_PATH}/img/profileicon/${profileIconId}.png`;
   return (
-    <Avatar>
+    <Avatar className={className}>
       <AvatarImage src={src} alt={profileIconId} />
       <AvatarFallback>
         <Icons.user />


### PR DESCRIPTION
no ticket:

- updated match history to select `championName` from `championNames` object to ensure correct name/asset path
- refactored all icon components 
  - icon components use intrinsic sizing
  - icon components use `className` to control asset size 
  